### PR TITLE
Implement Exchange game mode

### DIFF
--- a/Src/GameMode/Chicken.lua
+++ b/Src/GameMode/Chicken.lua
@@ -11,9 +11,9 @@ WoWGoldGambler.CHICKEN.startRolls = function(self)
     -- Informs players that the registration phase has ended and determines the roll amount (50% - 120% of the wager amount)
     SendChatMessage("Registration has ended. The bust amount is " ..  self:formatInt(self.db.global.game.wager) ..". Deciding the roll amount..." , self.db.global.game.chatChannel)
 
-    self.session.modeData.rollAmount = math.floor(self.db.global.game.wager * (math.random(50, 120) / 100))
+    self.session.modeData.currentRoll = math.floor(self.db.global.game.wager * (math.random(50, 120) / 100))
 
-    SendChatMessage("All players /roll " .. self.session.modeData.rollAmount .. " now! Be careful not to bust!" , self.db.global.game.chatChannel)
+    SendChatMessage("All players /roll " .. self.session.modeData.currentRoll .. " now! Be careful not to bust!" , self.db.global.game.chatChannel)
 
     for i = 1, #self.session.players do
         self.session.players[i].rollTotal = 0
@@ -23,7 +23,7 @@ end
 WoWGoldGambler.CHICKEN.recordRoll = function(self, playerName, actualRoll, minRoll, maxRoll)
     -- If a registered player rolled the correct amount and has not opted out of rolling, add the roll amount to their rollTotal
     -- If their rollTotal exceeds the wager amount, they bust and cannot continue rolling
-    if (tonumber(minRoll) == 1 and tonumber(maxRoll) == self.session.modeData.rollAmount) then
+    if (tonumber(minRoll) == 1 and tonumber(maxRoll) == self.session.modeData.currentRoll) then
         for i = 1, #self.session.players do
             if (self.session.players[i].name == playerName and self.session.players[i].roll == nil) then
                 self.session.players[i].rollTotal = self.session.players[i].rollTotal + tonumber(actualRoll)

--- a/Src/GameMode/Chicken.lua
+++ b/Src/GameMode/Chicken.lua
@@ -41,6 +41,26 @@ WoWGoldGambler.CHICKEN.recordRoll = function(self, playerName, actualRoll, minRo
     end
 end
 
+-- During this game mode, we continue listening to chat messages during the rolling phase
+-- Players will use the chat to let us know when they're done rolling
+WoWGoldGambler.CHICKEN.handleChatMessage = function(self, text, playerName, playerRealm)
+    -- If a registered player who has not yet locked in their roll enters "-1" in the chat, lock in their roll
+    if (text == "-1") then
+        for i = 1, #self.session.players do
+            if (self.session.players[i].name == playerName and self.session.players[i].roll == nil) then
+                self.session.players[i].roll = self.session.players[i].rollTotal
+                SendChatMessage(self.session.players[i].name .. " is done rolling!" , self.db.global.game.chatChannel)
+
+                if (#self:checkPlayerRolls() == 0) then
+                    self:calculateResult()
+                end
+
+                return
+            end
+        end
+    end
+end
+
 WoWGoldGambler.CHICKEN.calculateResult = function(self)
     -- Calculation logic for the Chicken game mode. Ties are allowed.
     -- Winner: The player(s) with the highest roll while not being larger than the wager amount
@@ -109,25 +129,3 @@ end
 
 -- Default Tie Resolution
 WoWGoldGambler.CHICKEN.detectTie = WoWGoldGambler.DEFAULT.detectTie
-
--- Custom implementation for Chicken game mode
--- During this game mode, we continue listening to chat messages during the rolling phase
--- Players will use the chat to let us know when they're done rolling
-
-function WoWGoldGambler:chickenOut(text, playerName, playerRealm)
-    -- If a registered player who has not yet locked in their roll enters "-1" in the chat, lock in their roll
-    if (text == "-1") then
-        for i = 1, #self.session.players do
-            if (self.session.players[i].name == playerName and self.session.players[i].roll == nil) then
-                self.session.players[i].roll = self.session.players[i].rollTotal
-                SendChatMessage(self.session.players[i].name .. " is done rolling!" , self.db.global.game.chatChannel)
-
-                if (#self:checkPlayerRolls() == 0) then
-                    self:calculateResult()
-                end
-
-                return
-            end
-        end
-    end
-end

--- a/Src/GameMode/Coinflip.lua
+++ b/Src/GameMode/Coinflip.lua
@@ -10,6 +10,7 @@ WoWGoldGambler.COINFLIP.register = WoWGoldGambler.DEFAULT.register
 WoWGoldGambler.COINFLIP.startRolls = function(self)
     -- Informs players that the registration phase has ended.
     SendChatMessage("Registration has ended. All players /roll 2 now!" , self.db.global.game.chatChannel)
+    self.session.modeData.currentRoll = 2
 end
 
 WoWGoldGambler.COINFLIP.recordRoll = function(self, playerName, actualRoll, minRoll, maxRoll)

--- a/Src/GameMode/Defaults.lua
+++ b/Src/GameMode/Defaults.lua
@@ -4,31 +4,6 @@ WoWGoldGambler.DEFAULT = {}
 WoWGoldGambler.DEFAULT.gameStart = function(self)
     -- Basic game start notification for most game modes
     SendChatMessage("WoWGoldGambler: A new game has been started! Type 1 to join! (-1 to withdraw)" , self.db.global.game.chatChannel)
-
-    -- TODO: REMOVE ME
-    local newPlayer = {
-        name = "Tester",
-        realm = "Ravencrest",
-        roll = 1,
-        pokerHand = {
-            type = "High Card",
-            cardRanks = {1}
-        }
-    }
-
-    tinsert(self.session.players, newPlayer)
-
-    local newPlayer2 = {
-        name = "Tester2",
-        realm = "Ravencrest",
-        roll = 2,
-        pokerHand = {
-            type = "High Card",
-            cardRanks = {2}
-        }
-    }
-
-    tinsert(self.session.players, newPlayer2)
 end
 
 WoWGoldGambler.DEFAULT.register = function(self, text, playerName, playerRealm)

--- a/Src/GameMode/Exchange.lua
+++ b/Src/GameMode/Exchange.lua
@@ -27,8 +27,7 @@ WoWGoldGambler.EXCHANGE.recordRoll = function(self, playerName, actualRoll, minR
         self.session.modeData.currentRoll = #self.session.players
 
         SendChatMessage(firstPlayerName .. ", you have been selected to make an exchange! Now, /roll " .. #self.session.players .. " to determine your opponent!", self.db.global.game.chatChannel)
-    -- TODO: Revert to self.session.modeData.firstPlayerName
-    elseif (self.session.dealer.name == playerName and self.session.modeData.secondPlayerIndex == nil and
+    elseif (self.session.modeData.firstPlayerName == playerName and self.session.modeData.secondPlayerIndex == nil and
             tonumber(minRoll) == 1 and tonumber(maxRoll) == #self.session.players) then
         local secondPlayerIndex = tonumber(actualRoll)
 
@@ -51,8 +50,7 @@ WoWGoldGambler.EXCHANGE.recordRoll = function(self, playerName, actualRoll, minR
         else
             SendChatMessage("You can't play against yourself! Let's try that again. " .. playerName .. ", /roll ".. #self.session.players .. " to determine your opponent!", self.db.global.game.chatChannel)
         end
-        -- TODO: Revert to self.session.modeData.loserName
-    elseif (self.session.dealer.name == playerName and self.session.modeData.amountOwed == nil and
+    elseif (self.session.modeData.loserName == playerName and self.session.modeData.amountOwed == nil and
             tonumber(minRoll) == 1 and tonumber(maxRoll) == self.db.global.game.wager) then
         self.session.modeData.amountOwed = tonumber(actualRoll)
 
@@ -66,8 +64,7 @@ end
 WoWGoldGambler.EXCHANGE.handleChatMessage = function(self, text, playerName, playerRealm)
     -- During this game mode, we continue listening to chat messages during the rolling phase
     -- Player 1 will use the chat to let us know when to stop cycling raid icons, determining the outcome
-    -- TODO: Revert to self.session.modeData.firstPlayerName
-    if (self.session.dealer.name == playerName and self.session.modeData.loserName == nil and string.upper(text) == "STOP") then
+    if (self.session.modeData.firstPlayerName == playerName and self.session.modeData.loserName == nil and string.upper(text) == "STOP") then
         -- If Player 1 has sent the message "STOP", and we have not yet determined the outcome,
         -- stop cycling raid icons and use the current raid icon to determine the outcome
         self:cycleRaidIcon(false)
@@ -78,26 +75,30 @@ WoWGoldGambler.EXCHANGE.handleChatMessage = function(self, text, playerName, pla
             -- Star Outcome
             self.session.modeData.loserName = self.session.modeData.secondPlayerName
             self.session.modeData.amountOwed = self.db.global.game.wager
+            SendChatMessage("{Star} How lucky! It looks like " .. self.session.modeData.loserName .. " will be donating the full wager amount!", self.db.global.game.chatChannel)
         elseif (raidIcon == 2) then
             -- Circle Outcome
             self.session.modeData.amountOwed = 0
+            SendChatMessage("{Circle} Aww, it looks like " .. self.session.modeData.firstPlayerName .. " and ".. self.session.modeData.secondPlayerName .. " have to exchange hugs!", self.db.global.game.chatChannel)
         elseif (raidIcon == 3) then
             -- Diamond Outcome
             self.session.modeData.loserName = self.session.modeData.secondPlayerName
+            SendChatMessage("{Diamond} It looks like " .. self.session.modeData.loserName .. " is feeling generous! ".. self.session.modeData.loserName .. ", /roll " .. self.db.global.game.wager .. " now to see how much you'll lose!", self.db.global.game.chatChannel)
         elseif (raidIcon == 7) then
             -- Cross Outcome
             self.session.modeData.loserName = self.session.modeData.firstPlayerName
+            SendChatMessage("{Cross} It looks like " .. self.session.modeData.loserName .. " is feeling generous! ".. self.session.modeData.loserName .. ", /roll " .. self.db.global.game.wager .. " now to see how much you'll lose!", self.db.global.game.chatChannel)
         elseif (raidIcon == 8) then
             -- Skull Outcome
             self.session.modeData.loserName = self.session.modeData.firstPlayerName
-            self.session.modeData.amountOwed = self.db.global.game.wager 
+            self.session.modeData.amountOwed = self.db.global.game.wager
+            SendChatMessage("{Skull} How generous! It looks like " .. self.session.modeData.loserName .. " will be donating the full wager amount!", self.db.global.game.chatChannel)
         end
         
         -- If outcome does not require a roll for self.session.modeData.amountOwed, calculate results
         if (self.session.modeData.amountOwed ~= nil) then
             self:calculateResult()
         else
-            SendChatMessage("It looks like " .. self.session.modeData.loserName .. " is feeling generous! ".. self.session.modeData.loserName .. ", /roll " .. self.db.global.game.wager .. " now to see how much you'll lose!", self.db.global.game.chatChannel)
             self.session.modeData.currentRoll = self.db.global.game.wager
         end
     end
@@ -117,8 +118,6 @@ WoWGoldGambler.EXCHANGE.calculateResult = function(self)
     elseif (self.session.modeData.secondPlayerName == self.session.modeData.loserName) then
         tinsert(winners, self.session.players[self.session.modeData.firstPlayerIndex])
         tinsert(losers, self.session.players[self.session.modeData.secondPlayerIndex])
-    else
-        SendChatMessage("Aww, it looks like " .. self.session.modeData.firstPlayerName .. " and ".. self.session.modeData.secondPlayerName .. " have to exchange hugs!", self.db.global.game.chatChannel)
     end
 
     return {

--- a/Src/GameMode/Exchange.lua
+++ b/Src/GameMode/Exchange.lua
@@ -1,0 +1,128 @@
+-- Exchange Game Mode --
+WoWGoldGambler.EXCHANGE = {}
+
+-- Default Game Start
+WoWGoldGambler.EXCHANGE.gameStart = WoWGoldGambler.DEFAULT.gameStart
+
+-- Default Registration
+WoWGoldGambler.EXCHANGE.register = WoWGoldGambler.DEFAULT.register
+
+WoWGoldGambler.EXCHANGE.startRolls = function(self) {
+    -- Informs players that the registration phase has ended and performs a /roll 2 to select the first of two players to play
+    SendChatMessage("Registration has ended. Let's see which players will be making an exchange!" , self.db.global.game.chatChannel)
+    self:rollMe(#self.session.players)
+}
+
+WoWGoldGambler.EXCHANGE.recordRoll = function(self, playerName, actualRoll, minRoll, maxRoll)
+    -- If the dealer made a roll for the number of players, use it to determine the first player
+    -- If the first player made a roll for the number of player, use it to determine the second player (must be different from the first roll)
+    -- If the losing player made a roll for the wager amount and the amount owed has not yet been determined, use it to determine the amount owed
+    if (self.session.dealer.name == playerName and self.session.modeData.firstPlayerIndex == nil and
+        tonumber(minRoll) == 1 and tonumber(maxRoll) == #self.session.players) then
+        local firstPlayerIndex = tonumber(actualRoll)
+        local firstPlayerName = self.session.players[firstPlayerIndex].name
+
+        self.session.modeData.firstPlayerIndex = firstPlayerIndex
+        self.session.modeData.firstPlayerName = firstPlayerName
+        self.session.modeData.currentRoll = #self.session.players
+
+        SendChatMessage(firstPlayerName .. ", you have been selected to make an exchange! Now, /roll " .. #self.session.players .. " to determine your opponent!", self.db.global.game.chatChannel)
+    elseif (self.session.modeData.firstPlayerName == playerName and self.session.modeData.secondPlayerIndex == nil and
+            tonumber(minRoll) == 1 and tonumber(maxRoll) == #self.session.players) then
+        local secondPlayerIndex = tonumber(actualRoll)
+
+        if (secondPlayerIndex ~= self.session.modeData.firstPlayerIndex) then
+            local secondPlayerName = self.session.players[secondPlayerIndex].name
+
+            self.session.modeData.secondPlayerIndex = secondPlayerIndex
+            self.session.modeData.secondPlayerName = secondPlayerName
+
+            SendChatMessage("Alright, " .. playerName .. " and ".. secondPlayerName .. " are about to make an exchange! Here are the possible outcomes!", self.db.global.game.chatChannel)
+            SendChatMessage("{Skull} " .. playerName .. " owes " .. secondPlayerName .. " " .. self.db.global.game.wager .. " gold", self.db.global.game.chatChannel)
+            SendChatMessage("{Cross} " .. playerName .. " owes " .. secondPlayerName .. " a rolled amount of gold", self.db.global.game.chatChannel)
+            SendChatMessage("{Circle} " .. playerName .. " and " .. secondPlayerName .. " must /hug", self.db.global.game.chatChannel)
+            SendChatMessage("{Diamond} " .. secondPlayerName .. " owes " .. playerName .. " a rolled amount of gold", self.db.global.game.chatChannel)
+            SendChatMessage("{Star} " .. secondPlayerName .. " owes " .. playerName .. " " .. self.db.global.game.wager .. " gold", self.db.global.game.chatChannel)
+
+            self:cycleRaidIconToggle(true)
+
+            SendChatMessage("Now, " .. playerName .. ", notice the raid icons cycling above my head. When you're ready, type STOP in chat to determine the outcome!", self.db.global.game.chatChannel)
+        else
+            SendChatMessage("You can't play against yourself! Let's try that again. " .. playerName .. ", /roll ".. #self.session.players .. " to determine your opponent!", self.db.global.game.chatChannel)
+        end
+    elseif (self.session.modeData.loserName == playerName and self.session.modeData.amountOwed == nil and
+            tonumber(minRoll) == 1 and tonumber(maxRoll) == self.db.global.game.wager) then
+        self.session.modeData.amountOwed = tonumber(actualRoll)
+
+        -- Since all players must have a recorded roll for the game to end, simply give players a default roll
+        for i = 1, #self.session.players do
+            self.session.players[i].roll = i
+        end
+    end
+end
+
+WoWGoldGambler.EXCHANGE.handleChatMessage = function(self, text, playerName, playerRealm)
+    -- During this game mode, we continue listening to chat messages during the rolling phase
+    -- Player 1 will use the chat to let us know when to stop cycling raid icons, determining the outcome
+    if (self.session.modeData.firstPlayerName == playerName and self.session.modeData.loserName == nil and string.upper(text) == "STOP") then
+        -- If Player 1 has sent the message "STOP", and we have not yet determined the outcome,
+        -- stop cycling raid icons and use the current raid icon to determine the outcome
+        self:cycleRaidIcon(false)
+
+        local raidIcon = GetRaidTargetIndex("player");
+
+        if (raidIcon == 1) then
+            -- Star Outcome
+            self.session.modeData.loserName = self.session.modeData.secondPlayerName
+            self.session.modeData.amountOwed = self.db.global.game.wager
+        else if (raidIcon == 2) then
+            -- Circle Outcome
+            self.session.modeData.amountOwed = 0
+        else if (raidIcon == 3) then
+            -- Diamond Outcome
+            self.session.modeData.loserName = self.session.modeData.secondPlayerName
+        else if (raidIcon == 7) then
+            -- Cross Outcome
+            self.session.modeData.loserName = self.session.modeData.firstPlayerName
+        else if (raidIcon == 8) then
+            -- Skull Outcome
+            self.session.modeData.loserName = self.session.modeData.firstPlayerName
+            self.session.modeData.amountOwed = self.db.global.game.wager 
+        end
+        
+        -- If outcome does not require a roll for self.session.modeData.amountOwed, calculate results
+        if (self.session.modeData.amountOwed ~= nil) then
+            self:calculateResult()
+        else
+            SendChatMessage("It looks like " .. self.session.modeData.loserName .. " is feeling generous! ".. self.session.modeData.loserName .. ", /roll " .. self.db.global.game.wager .. " now to see how much you'll lose!", self.db.global.game.chatChannel)
+        end
+    end
+end
+
+WoWGoldGambler.EXCHANGE.calculateResult = function(self)
+    -- Calculation logic for the Exchange game mode. The game may end in a tie if the Circle outcome was chosen.
+    -- Winner: The winner is determined by the selected outcome
+    -- Loser: The loser is determined by the selected outcome
+    -- Payment Amount: Either the wager amount, or a rolled amount that is less than the wager
+    local winners = {}
+    local losers = {}
+
+    if (self.session.modeData.firstPlayerName == self.session.modeData.loserName) then
+        tinsert(winners, self.session.players[self.session.modeData.secondPlayerIndex])
+        tinsert(losers, self.session.players[self.session.modeData.firstPlayerIndex])
+    elseif (self.session.modeData.secondPlayerName == self.session.modeData.loserName) then
+        tinsert(winners, self.session.players[self.session.modeData.firstPlayerIndex])
+        tinsert(losers, self.session.players[self.session.modeData.secondPlayerIndex])
+    else
+        SendChatMessage("Aww, it looks like " .. self.session.modeData.firstPlayerName .. " and ".. self.session.modeData.secondPlayerName .. " have to exchange hugs!", self.db.global.game.chatChannel)
+    end
+
+    return {
+        winners = winners,
+        losers = losers,
+        amountOwed = self.session.modeData.amountOwed
+    }
+end
+
+-- Default Tie Resolution
+WoWGoldGambler.EXCHANGE.detectTie = WoWGoldGambler.DEFAULT.detectTie

--- a/Src/GameMode/Exchange.lua
+++ b/Src/GameMode/Exchange.lua
@@ -7,11 +7,11 @@ WoWGoldGambler.EXCHANGE.gameStart = WoWGoldGambler.DEFAULT.gameStart
 -- Default Registration
 WoWGoldGambler.EXCHANGE.register = WoWGoldGambler.DEFAULT.register
 
-WoWGoldGambler.EXCHANGE.startRolls = function(self) {
+WoWGoldGambler.EXCHANGE.startRolls = function(self)
     -- Informs players that the registration phase has ended and performs a /roll 2 to select the first of two players to play
     SendChatMessage("Registration has ended. Let's see which players will be making an exchange!" , self.db.global.game.chatChannel)
     self:rollMe(#self.session.players)
-}
+end
 
 WoWGoldGambler.EXCHANGE.recordRoll = function(self, playerName, actualRoll, minRoll, maxRoll)
     -- If the dealer made a roll for the number of players, use it to determine the first player
@@ -27,7 +27,8 @@ WoWGoldGambler.EXCHANGE.recordRoll = function(self, playerName, actualRoll, minR
         self.session.modeData.currentRoll = #self.session.players
 
         SendChatMessage(firstPlayerName .. ", you have been selected to make an exchange! Now, /roll " .. #self.session.players .. " to determine your opponent!", self.db.global.game.chatChannel)
-    elseif (self.session.modeData.firstPlayerName == playerName and self.session.modeData.secondPlayerIndex == nil and
+    -- TODO: Revert to self.session.modeData.firstPlayerName
+    elseif (self.session.dealer.name == playerName and self.session.modeData.secondPlayerIndex == nil and
             tonumber(minRoll) == 1 and tonumber(maxRoll) == #self.session.players) then
         local secondPlayerIndex = tonumber(actualRoll)
 
@@ -38,19 +39,20 @@ WoWGoldGambler.EXCHANGE.recordRoll = function(self, playerName, actualRoll, minR
             self.session.modeData.secondPlayerName = secondPlayerName
 
             SendChatMessage("Alright, " .. playerName .. " and ".. secondPlayerName .. " are about to make an exchange! Here are the possible outcomes!", self.db.global.game.chatChannel)
-            SendChatMessage("{Skull} " .. playerName .. " owes " .. secondPlayerName .. " " .. self.db.global.game.wager .. " gold", self.db.global.game.chatChannel)
+            SendChatMessage("{Skull} " .. playerName .. " owes " .. secondPlayerName .. " " .. self:formatInt(self.db.global.game.wager) .. " gold", self.db.global.game.chatChannel)
             SendChatMessage("{Cross} " .. playerName .. " owes " .. secondPlayerName .. " a rolled amount of gold", self.db.global.game.chatChannel)
             SendChatMessage("{Circle} " .. playerName .. " and " .. secondPlayerName .. " must /hug", self.db.global.game.chatChannel)
             SendChatMessage("{Diamond} " .. secondPlayerName .. " owes " .. playerName .. " a rolled amount of gold", self.db.global.game.chatChannel)
-            SendChatMessage("{Star} " .. secondPlayerName .. " owes " .. playerName .. " " .. self.db.global.game.wager .. " gold", self.db.global.game.chatChannel)
+            SendChatMessage("{Star} " .. secondPlayerName .. " owes " .. playerName .. " " .. self:formatInt(self.db.global.game.wager) .. " gold", self.db.global.game.chatChannel)
 
-            self:cycleRaidIconToggle(true)
+            self:cycleRaidIcon(true)
 
             SendChatMessage("Now, " .. playerName .. ", notice the raid icons cycling above my head. When you're ready, type STOP in chat to determine the outcome!", self.db.global.game.chatChannel)
         else
             SendChatMessage("You can't play against yourself! Let's try that again. " .. playerName .. ", /roll ".. #self.session.players .. " to determine your opponent!", self.db.global.game.chatChannel)
         end
-    elseif (self.session.modeData.loserName == playerName and self.session.modeData.amountOwed == nil and
+        -- TODO: Revert to self.session.modeData.loserName
+    elseif (self.session.dealer.name == playerName and self.session.modeData.amountOwed == nil and
             tonumber(minRoll) == 1 and tonumber(maxRoll) == self.db.global.game.wager) then
         self.session.modeData.amountOwed = tonumber(actualRoll)
 
@@ -64,7 +66,8 @@ end
 WoWGoldGambler.EXCHANGE.handleChatMessage = function(self, text, playerName, playerRealm)
     -- During this game mode, we continue listening to chat messages during the rolling phase
     -- Player 1 will use the chat to let us know when to stop cycling raid icons, determining the outcome
-    if (self.session.modeData.firstPlayerName == playerName and self.session.modeData.loserName == nil and string.upper(text) == "STOP") then
+    -- TODO: Revert to self.session.modeData.firstPlayerName
+    if (self.session.dealer.name == playerName and self.session.modeData.loserName == nil and string.upper(text) == "STOP") then
         -- If Player 1 has sent the message "STOP", and we have not yet determined the outcome,
         -- stop cycling raid icons and use the current raid icon to determine the outcome
         self:cycleRaidIcon(false)
@@ -75,16 +78,16 @@ WoWGoldGambler.EXCHANGE.handleChatMessage = function(self, text, playerName, pla
             -- Star Outcome
             self.session.modeData.loserName = self.session.modeData.secondPlayerName
             self.session.modeData.amountOwed = self.db.global.game.wager
-        else if (raidIcon == 2) then
+        elseif (raidIcon == 2) then
             -- Circle Outcome
             self.session.modeData.amountOwed = 0
-        else if (raidIcon == 3) then
+        elseif (raidIcon == 3) then
             -- Diamond Outcome
             self.session.modeData.loserName = self.session.modeData.secondPlayerName
-        else if (raidIcon == 7) then
+        elseif (raidIcon == 7) then
             -- Cross Outcome
             self.session.modeData.loserName = self.session.modeData.firstPlayerName
-        else if (raidIcon == 8) then
+        elseif (raidIcon == 8) then
             -- Skull Outcome
             self.session.modeData.loserName = self.session.modeData.firstPlayerName
             self.session.modeData.amountOwed = self.db.global.game.wager 
@@ -95,6 +98,7 @@ WoWGoldGambler.EXCHANGE.handleChatMessage = function(self, text, playerName, pla
             self:calculateResult()
         else
             SendChatMessage("It looks like " .. self.session.modeData.loserName .. " is feeling generous! ".. self.session.modeData.loserName .. ", /roll " .. self.db.global.game.wager .. " now to see how much you'll lose!", self.db.global.game.chatChannel)
+            self.session.modeData.currentRoll = self.db.global.game.wager
         end
     end
 end

--- a/Src/GameMode/Poker.lua
+++ b/Src/GameMode/Poker.lua
@@ -21,6 +21,8 @@ WoWGoldGambler.POKER.register = WoWGoldGambler.DEFAULT.register
 WoWGoldGambler.POKER.startRolls = function(self)
     -- Informs players that the registration phase has ended.
     SendChatMessage("Registration has ended. All players /roll 11111-99999 now!" , self.db.global.game.chatChannel)
+    self.session.modeData.currentMinRoll = 11111
+    self.session.modeData.currentRoll = 99999
 end
 
 WoWGoldGambler.POKER.recordRoll = function(self, playerName, actualRoll, minRoll, maxRoll)

--- a/Src/WoWGoldGambler.lua
+++ b/Src/WoWGoldGambler.lua
@@ -14,7 +14,8 @@ local gameModes = {
     "PRICE IS RIGHT",
     "POKER",
     "CHICKEN",
-    "1v1 DEATH ROLL"
+    "1v1 DEATH ROLL",
+    "EXCHANGE"
 }
 
 local chatChannels = {
@@ -192,8 +193,8 @@ function WoWGoldGambler:handleChatMessage(_, text, playerName)
         WoWGoldGambler[self.db.global.game.mode].register(WoWGoldGambler, text, playerName, playerRealm)
     elseif (self.session.state == gameStates[3]) then
         -- If we're still listening to chat messages during the rolling phase of a game, perform game-mode specific actions
-        if (self.db.global.game.mode == "CHICKEN") then
-            self:chickenOut(text, playerName, playerRealm)
+        if (WoWGoldGambler[self.db.global.game.mode].handleChatMessage ~= nil) then
+            WoWGoldGambler[self.db.global.game.mode].handleChatMessage(WoWGoldGambler, text, playerName, playerRealm)
         end
     end
 end
@@ -398,7 +399,7 @@ function WoWGoldGambler:startRolls()
         -- At least two players are required to play
         if (#self.session.players > 1) then
             -- Stop listening to chat messages unless they are required for the game mode
-            if (self.db.global.game.mode ~= "CHICKEN") then
+            if (WoWGoldGambler[self.db.global.game.mode].handleChatMessage == nil) then
                 self:UnregisterEvent("CHAT_MSG_PARTY")
                 self:UnregisterEvent("CHAT_MSG_PARTY_LEADER")
                 self:UnregisterEvent("CHAT_MSG_RAID")
@@ -576,6 +577,7 @@ function WoWGoldGambler:endGame()
     self.session.players = {}
     self.session.result = nil
     self.session.modeData = {}
+    self:cycleRaidIcon(false)
 
     -- Update UI Widgets
     self:updateUi(self.session.state, gameStates)

--- a/Src/WoWGoldGambler.lua
+++ b/Src/WoWGoldGambler.lua
@@ -437,13 +437,7 @@ function WoWGoldGambler:rollMe(maxAmount, minAmount)
     -- Automatically performs a roll between [minAmount] and [maxAmount] for the dealer.
     -- If [maxValue] or [minValue] are nil, they are defaulted to appropriate values for the game mode
     if (maxAmount == nil) then
-        if (self.db.global.game.mode == "COINFLIP") then
-            maxAmount = 2
-        elseif (self.db.global.game.mode == "POKER") then
-            maxAmount = 99999
-        elseif (self.db.global.game.mode == "CHICKEN") then
-            maxAmount = self.session.modeData.rollAmount
-        elseif (self.db.global.game.mode == "1v1 DEATH ROLL") then
+        if (self.session.modeData.currentRoll ~= nil) then
             maxAmount = self.session.modeData.currentRoll
         else
             maxAmount = self.db.global.game.wager
@@ -451,8 +445,8 @@ function WoWGoldGambler:rollMe(maxAmount, minAmount)
     end
 
     if (minAmount == nil) then
-        if (self.db.global.game.mode == "POKER") then
-            minAmount = 11111
+        if (self.session.modeData.currentMinRoll ~= nil) then
+            minAmount = self.session.modeData.currentMinRoll
         else
             minAmount = 1
         end

--- a/Src/ui.lua
+++ b/Src/ui.lua
@@ -184,6 +184,41 @@ function WoWGoldGambler:updateUi(currentState, gameStates)
     end
 end
 
+local currentIcon = nil
+local raidIcons = {
+    1, -- Star
+    2, -- Circle
+    3, -- Diamond
+    7, -- Cross
+    8  -- Skull
+}
+
+function WoWGoldGambler:cycleRaidIcon(startOrStop)
+    -- Starts or stops raid icon cycling on the Dealer
+    if (startOrStop == false) then
+        -- Stop cycling raid icons unless already stopped
+        if (currentIcon ~= nil) then
+            tinsert(raidIcons, currentIcon)
+            currentIcon = nil
+            container:SetScript("OnUpdate", nil)
+        end
+    elseif (startOrStop == true) then
+        -- Start cycling raid icons unless already started
+        if (currentIcon == nil) then
+            container:SetScript("OnUpdate", function()
+                local randomIndex = math.random(#raidIcons)
+                local randomIcon = raidIcons[randomIndex]
+    
+                tremove(raidIcons, randomIndex)
+                tinsert(raidIcons, currentIcon)
+                currentIcon = randomIcon
+    
+                SetRaidTarget("player", randomIcon)
+            end)
+        end
+    end
+end
+
 -- Implementation Functions --
 
 function WoWGoldGambler:enableWidget(widget)

--- a/WoWGoldGambler.toc
+++ b/WoWGoldGambler.toc
@@ -1,7 +1,7 @@
 ## Interface: 110002
 ## Title: WoWGoldGambler
 ## Author: Ormannishe
-## Version: v2.0.0
+## Version: v2.1.0
 ## Notes: May RNG be ever in your favor.
 ## SavedVariables: WoWGoldGamblerDB
 ## OptionalDeps: Ace3
@@ -18,5 +18,6 @@ Src/GameMode/Lottery.lua
 Src/GameMode/PriceIsRight.lua
 Src/GameMode/Poker.lua
 Src/GameMode/DeathRoll.lua
+Src/GameMode/Exchange.lua
 Src/Stats.lua
 Src/ui.lua


### PR DESCRIPTION
- Adds a new game mode: Exchange
  - Two registered players are randomly selected to exchange an amount of gold (Player 1 is determined by a dealer roll, and Player 2 is determined by a roll from Player 1)
  - Once players are determined, raid icons will begin rapidly cycling over the Dealer's head
  - Player 1 must type "STOP" in chat to stop the cycling
  - The raid icon on the Dealer at the time of stopping is used to determine the outcome
  - If a "rolled amount" outcome is chosen, the losing player must perform a /roll for the wager amount to determine how much they'll lose
- Also added some improvements
  - Standardized the use of `modeData.currentRoll` for game modes which use a non-standard roll
    - This genericizes the logic for performing rolls for the Dealer
    - `modeData.currentMinRoll` is used for rolls which require a lower-bound (ie. poker)
  - Added a standard game mode function, `handleChatMessage` for game modes which continue listening to chat messages during the ROLLING phase